### PR TITLE
Fixed D.d having a byte order mark

### DIFF
--- a/templates/D.d
+++ b/templates/D.d
@@ -1,4 +1,4 @@
-﻿import std.traits : Unqual;
+import std.traits : Unqual;
 
 alias int64_t = long;
 alias uint64_t = ulong;


### PR DESCRIPTION
Annoyed me in the text editor (unknown unicode character inside it, because it gets added in the middle of the file) and I think it causes problems with D