### PR TITLE
Fix compilation errors and segfault

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
 		"rikki"
 	],
 	"dependencies": {
-		"std-experimental-xml-live": "~>0.1.4"
+		"std-experimental-xml": "~>0.1.7"
 	},
 	"description": "A minimal D application.",
 	"copyright": "Copyright © 2016, rikki",

--- a/source/util.d
+++ b/source/util.d
@@ -1,7 +1,7 @@
 ﻿module util;
 
 const(char)[] removeUnicodeBOM(const(char)[] input) {
-	if (input.length >= 3 && input[0 .. 3] == x"ef bb bf") {
+	if (input.length >= 3 && input[0 .. 3] == "\xef\xbb\xbf") {
 		return input[3 .. $];
 	} else {
 		return input;
@@ -10,7 +10,7 @@ const(char)[] removeUnicodeBOM(const(char)[] input) {
 
 pure string replace(string text, string oldText, string newText, bool caseSensitive = true, bool first = false) {
 	import std.uni : toLower;
-	
+
 	string ret;
 	string tempData;
 	bool stop;
@@ -31,7 +31,7 @@ pure string replace(string text, string oldText, string newText, bool caseSensit
 		}
 	}
 	if (tempData != "") {
-		ret ~= tempData;	
+		ret ~= tempData;
 	}
 	return ret;
 }
@@ -84,25 +84,25 @@ string fixTypePointer(string input) {
 	char[] buffer, buffer2;
 	buffer.length = input.length;
 	buffer[] = input[];
-	
+
 	size_t i;
 	while(i < buffer.length) {
 		char c = buffer[i];
 		char c2 = '\0';
-		
+
 		if (i + 1 < buffer.length)
 			c2 = buffer[i + 1];
-		
+
 		if (c == ' ') {
 			if (c2 == '*') {
 				buffer[i] = '*';
 				buffer[i + 1] = ' ';
 			}
 		}
-		
+
 		i++;
 	}
-	
+
 	string ret = cast(string)buffer.strip;
 	if (ret == "const GLvoid*  const*" || ret == "const GLchar* const*" || ret == "const void* const*")
 		return "const(const(GLvoid*)*)";


### PR DESCRIPTION
I tried to run this command:
```
dub run ogl_gen -- --gen-d=gl4.d --gen-d-module=gl4 --load-core-4.5 --load-core-3 --load-core-2 --load-spec
```
But I first got compilation errors and then a segfault, so I fixed them:
- use newest version of `std-experimental-xml` package instead of `std-experimental-xml-live`
- replace `childNodes[1]` with `childNodes.item(1)` because the package doesn't support operator overloads
- replace hex string `x"ef bb bf"` with `"\xef\xbb\xbf"`
- add `current.attributes is null` check for trademark section to fix segfault (copied from the "emphasis" case, I don't understand the code so I hope it's correct)

The PR also removes trailing whitespace which my editor does automatically, I can undo it if it's a problem.