### PR TITLE
Remove unused Unqual import

### DIFF
--- a/templates/D.d
+++ b/templates/D.d
@@ -1,5 +1,3 @@
-import std.traits : Unqual;
-
 alias int64_t = long;
 alias uint64_t = ulong;
 alias int32_t = int;


### PR DESCRIPTION
The symbol `Unqual` appears nowhere else in the repository, so it looks like a useless Phobos import.