### PR TITLE
Make GLsizei a signed integer

### DIFF
--- a/templates/D.d
+++ b/templates/D.d
@@ -27,7 +27,7 @@ alias GLint64 = long;
 ///
 alias GLuint64 = ulong;
 ///
-alias GLsizei = uint;
+alias GLsizei = int;
 ///
 alias GLenum = uint;
 ///


### PR DESCRIPTION
While `GLsizei` is specified to be a non-negative 32-bit integer, it's de facto defined as a signed integer in GLEW, glad, derelict-gl3, bindbc-opengl, etc. Often it doesn't matter since `int` converts to `uint` and vice versa, but when a function takes a `GLsizei` pointer (such as `glGetShaderInfoLog`) it must match exactly.

See also: [Why isn't GLsizei defined as unsigned?](https://stackoverflow.com/questions/8996743/why-isnt-glsizei-defined-as-unsigned)